### PR TITLE
Feat/shader array defs

### DIFF
--- a/plugins/metadata/arnold_operators.mtd
+++ b/plugins/metadata/arnold_operators.mtd
@@ -16,7 +16,6 @@
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "operator"
 soft.inspectable BOOL false
 
 ###########################################################################
@@ -26,7 +25,6 @@ soft.inspectable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "operator"
 soft.inspectable BOOL false
 
 [attr mode]
@@ -51,7 +49,6 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "operator"
 soft.inspectable BOOL false
 
 [attr assign_materials]
@@ -70,7 +67,6 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "operator"
 soft.inspectable BOOL false
 
 ###########################################################################
@@ -80,7 +76,6 @@ soft.inspectable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "operator"
 soft.inspectable BOOL false
 
 [attr assignment]
@@ -93,7 +88,6 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "operator"
 soft.inspectable BOOL false
 
 [attr translate]
@@ -112,7 +106,6 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "operator"
 soft.inspectable BOOL false
 
 [attr index]

--- a/plugins/metadata/arnold_operators.mtd
+++ b/plugins/metadata/arnold_operators.mtd
@@ -16,7 +16,8 @@
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "shader array"
+soft.node_type STRING "operator"
+soft.inspectable BOOL false
 
 ###########################################################################
 [node disable]
@@ -25,7 +26,8 @@ soft.node_type STRING "shader array"
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "shader array"
+soft.node_type STRING "operator"
+soft.inspectable BOOL false
 
 [attr mode]
 linkable BOOL false
@@ -49,7 +51,8 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "shader array"
+soft.node_type STRING "operator"
+soft.inspectable BOOL false
 
 [attr assign_materials]
 linkable BOOL false
@@ -67,7 +70,8 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "shader array"
+soft.node_type STRING "operator"
+soft.inspectable BOOL false
 
 ###########################################################################
 [node set_parameter]
@@ -76,7 +80,8 @@ soft.node_type STRING "shader array"
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "shader array"
+soft.node_type STRING "operator"
+soft.inspectable BOOL false
 
 [attr assignment]
 linkable BOOL false
@@ -88,7 +93,8 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "shader array"
+soft.node_type STRING "operator"
+soft.inspectable BOOL false
 
 [attr translate]
 linkable BOOL false
@@ -106,7 +112,8 @@ linkable BOOL false
 linkable BOOL false
 
 [attr inputs]
-soft.node_type STRING "shader array"
+soft.node_type STRING "operator"
+soft.inspectable BOOL false
 
 [attr index]
 linkable BOOL false

--- a/plugins/sitoa/common/Tools.cpp
+++ b/plugins/sitoa/common/Tools.cpp
@@ -510,6 +510,34 @@ bool CStringUtilities::EndsWith(CString in_string, CString in_subString)
 }
 
 
+// Converts a parameter name to prettier Title Case formated string
+//
+// @param in_string        The input string
+//
+// @return the string in Title Case format
+//
+CString CStringUtilities::PrettifyParameterName(CString in_string)
+{
+   CString label;
+   // replace "_" with " ". "_" is very common in the Arnold nodes
+   // Ex: "emission_color" -> "emission color: 
+   CString t_label = CStringUtilities().ReplaceString(L"_", L" ", in_string);
+   // capitalize the first char of the name, and each token after a space, as we do for the SItoA shaders
+   // Ex: "emission color" -> "Emission Color: 
+   for (ULONG i=0; i<t_label.Length(); i++)
+   {
+      if (i==0)
+         label+= (char)toupper(t_label[i]);
+      else if (t_label[i-1] == ' ')
+         label+= (char)toupper(t_label[i]);
+      else
+         label+= t_label[i];
+   }
+
+   return label;
+}
+
+
 ////////////////////////////////////////////////////
 ////////////////////////////////////////////////////
 ////////////////////////////////////////////////////

--- a/plugins/sitoa/common/Tools.h
+++ b/plugins/sitoa/common/Tools.h
@@ -351,6 +351,8 @@ public:
    bool StartsWith(CString in_string, CString in_subString);
    // Checks if string ends with substring
    bool EndsWith(CString in_string, CString in_subString);
+   // Converts a parameter name to prettier Title Case formated string
+   CString PrettifyParameterName(CString in_string);
 
 private:
    // Build the name for an Arnold node (overload for a CString input type)

--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -584,7 +584,7 @@ CString CShaderDefShader::Define(const bool in_clone_vector_map)
    if (m_is_passthrough_closure) // hack the closure output for the closure connector to color
       outParamDef.AddParamDef("out", siShaderDataTypeColor4, outOpts);
    else if (m_is_operator_node)
-      outParamDef.AddParamDef("out", L"operator", outOpts);
+      outParamDef.AddParamDef("out", siShaderDataTypeReference, outOpts);
    else
    {
       if (m_type == AI_TYPE_CLOSURE)

--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -117,7 +117,10 @@ siShaderReferenceFilterType GetShaderReferenceFilterType(CString in_type)
    else if (in_type == L"userdata")
       return siUserDataBlobReferenceFilter;
    else
+   {
+      GetMessageQueue()->LogMsg(L"[sitoa] Unknown ReferenceFilterType: \"" + in_type + L"\". Check your metadata file.", siWarningMsg);
       return siUnknownReferenceFilter;
+   }
 }
 
 

--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -265,14 +265,6 @@ void CShaderDefParameter::Define(ShaderParamDefContainer &in_paramDef, const CSt
       customNodeType = L"closure";
 
    ShaderParamDef pDef;
-   if (!paramIsArray)
-   {
-      if (customNodeType != "")
-         pDef = in_paramDef.AddParamDef(m_name, customNodeType, defOptions);
-      else
-         pDef = in_paramDef.AddParamDef(m_name, GetParamSdType(paramType), defOptions);
-   }
-
    if (paramIsArray)
    {
       // shaderarrays doesn't use the label but uses SetLongName instead
@@ -287,6 +279,13 @@ void CShaderDefParameter::Define(ShaderParamDefContainer &in_paramDef, const CSt
          pDef = in_paramDef.AddArrayParamDef(m_name, customNodeType, defOptions);
       else
          pDef = in_paramDef.AddArrayParamDef(m_name, GetParamSdType(paramType), defOptions);
+   }
+   else
+   {
+      if (customNodeType != "")
+         pDef = in_paramDef.AddParamDef(m_name, customNodeType, defOptions);
+      else
+         pDef = in_paramDef.AddParamDef(m_name, GetParamSdType(paramType), defOptions);
    }
 
    // setting the default for the struct parameters

--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -239,15 +239,11 @@ void CShaderDefParameter::Define(ShaderParamDefContainer &in_paramDef, const CSt
       paramType = AI_TYPE_NODE;
       CStringArray nodeTypes = CStringUtilities().ToLower(m_node_type).Split(L" ");
       CString nodeType = nodeTypes[0];
-      if (nodeType == L"operator")
-         customNodeType = nodeType;
-      else
-      {
-         // force node type even if string (toon shader uses this)
-         paramType = AI_TYPE_NODE;
-         // set the reference filter type
-         defOptions.SetAttribute(siReferenceFilterAttribute, GetShaderReferenceFilterType(nodeType));
-      }
+
+      // force node type even if string (toon shader uses this)
+      paramType = AI_TYPE_NODE;
+      // set the reference filter type
+      defOptions.SetAttribute(siReferenceFilterAttribute, GetShaderReferenceFilterType(nodeType));
 
       if (nodeTypes.GetCount() > 1)
       {

--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -343,23 +343,7 @@ void CShaderDefParameter::Layout(PPGLayout &in_layout)
    if (m_has_label)
       label = m_label;
    else
-   {
-      // replace "_" with " ". "_" is very common in the Arnold nodes
-      // Ex: "emission_color" -> "emission color: 
-      CString t_label = CStringUtilities().ReplaceString(L"_", L" ", m_name);
-
-      // capitalize the first char of the name, and each token after a space, as we do for the SItoA shaders
-      // Ex: "emission color" -> "Emission Color: 
-      for (ULONG i=0; i<t_label.Length(); i++)
-      {
-         if (i==0)
-            label+= (char)toupper(t_label[i]);
-         else if (t_label[i-1] == ' ')
-            label+= (char)toupper(t_label[i]);
-         else
-            label+= t_label[i];
-      }
-   }
+      label = CStringUtilities().PrettifyParameterName(m_name);
 
    // if a string parameter is called "filename", it's reasonable to provide a file browser widget
    if (m_type == AI_TYPE_STRING && m_name == ATSTRING::filename)

--- a/plugins/sitoa/renderer/Renderer.cpp
+++ b/plugins/sitoa/renderer/Renderer.cpp
@@ -236,7 +236,7 @@ SITOA_CALLBACK ArnoldRender_Define(CRef &in_ctxt)
    ShaderStructParamDef structParam(renderPassDef);
    ShaderParamDefContainer container = structParam.GetSubParamDefs();
 
-   container.AddParamDef(L"operator", L"operator", paramOptions);
+   container.AddParamDef(L"operator", siShaderDataTypeReference, paramOptions);
 
    return CStatus::OK;
 }


### PR DESCRIPTION
- Support for shader arrays, all types, all cases (I think)
- Made shader params code more generic. That means I removed all corner case code I had before.

`soft.node_type STRING "operator"` is needed for it to know what type it is.

Right now it's ONLY operators that uses the array type. And toon shader of course but that is because it's overridden in the metadata. It's not an array in the actual toon shader in Arnold.

I haven't run the testsuite but I don't think there will be any problems.